### PR TITLE
fix: make options for planExecution really optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,12 @@
   "homepage": "https://github.com/gnosisguild/ser-kit",
   "packageManager": "bun@1.1.12",
   "main": "dist/index.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  ".": {
+  "exports": {
+    "types": "./dist/index.d.ts",
     "import": "./dist/index.mjs",
-    "require": "./dist/index.js",
-    "default": "./dist/index.js"
+    "require": "./dist/index.js"
   },
   "files": [
     "dist",

--- a/src/execute/plan.ts
+++ b/src/execute/plan.ts
@@ -70,7 +70,7 @@ interface Options {
 export const planExecution = async (
   transactions: readonly MetaTransactionRequest[],
   route: Route,
-  options: Options
+  options: Options = {}
 ): Promise<ExecutionPlan> => {
   // encode batch using the appropriate multiSend contract address
   const lastRolesAccount = route.waypoints.findLast(


### PR DESCRIPTION
The description states options are optional but the way the method was currently typed they would be required. I've also adjusted the `package.json` slightly to define exports for all kinds of bundlers (e.g. the top-level `module` field was missing). AFAICT there are some issues with resolving stuff (at least based on my update PR).

Relates to https://github.com/gnosisguild/zodiac-pilot/pull/321