### PR TITLE
fix: parsePrefixedAddress handles prefixed addresses and regular ones

### DIFF
--- a/src/addresses.test.ts
+++ b/src/addresses.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'bun:test'
+import { parsePrefixedAddress } from './addresses'
+import { zeroAddress } from 'viem'
+
+describe('parsePrefixedAddress', () => {
+  it('returns the address part of a prefixed address', () => {
+    expect(parsePrefixedAddress(`eth:${zeroAddress}`)).toEqual(zeroAddress)
+  })
+
+  it('is the identify function when the input is already an address', () => {
+    expect(parsePrefixedAddress(zeroAddress)).toEqual(zeroAddress)
+  })
+})

--- a/src/addresses.ts
+++ b/src/addresses.ts
@@ -32,6 +32,10 @@ export const splitPrefixedAddress = (prefixedAddress: PrefixedAddress) => {
 export const parsePrefixedAddress = (
   prefixedAddress: PrefixedAddress | Address
 ) => {
+  if (!prefixedAddress.includes(':')) {
+    return getAddress(prefixedAddress) as `0x${string}`
+  }
+
   const [, address] = prefixedAddress.split(':')
   return getAddress(address) as `0x${string}`
 }


### PR DESCRIPTION
The method's type requires it to handle both prefixed and regular non-prefixed addresses. However, the implementation did not accommodate that. This PR adds the "missing" functionality and also a regression test.