### PR TITLE
fix: error when not supplying a provider

### DIFF
--- a/src/execute/plan.ts
+++ b/src/execute/plan.ts
@@ -2,8 +2,9 @@ import assert from 'assert'
 import { decodeFunctionData, hashTypedData, parseAbi, zeroAddress } from 'viem'
 import { Eip1193Provider } from '@safe-global/protocol-kit'
 
-import { encodeMultiSend } from './multisend'
 import { createPreApprovedSignature } from './signatures'
+import { encodeMultiSend } from './multisend'
+import { prepareSafeTransaction } from './safeTransaction'
 
 import { splitPrefixedAddress } from '../addresses'
 import { typedDataForSafeTransaction } from '../eip712'
@@ -35,7 +36,6 @@ import {
   type Route,
   type Waypoint,
 } from '../types'
-import prepareSafeTransaction from './prepareSafeTransaction'
 
 interface Options {
   /** Allows specifying which role to choose at any Roles node in the route in case multiple roles are available. */

--- a/src/execute/prepareSafeTransaction.ts
+++ b/src/execute/prepareSafeTransaction.ts
@@ -60,6 +60,7 @@ export default async function prepareSafeTransaction({
             args: [],
           }),
         },
+        'latest',
       ],
     })) as string
   )

--- a/src/execute/prepareSafeTransaction.ts
+++ b/src/execute/prepareSafeTransaction.ts
@@ -1,0 +1,113 @@
+import {
+  Address,
+  createPublicClient,
+  encodeFunctionData,
+  getAddress,
+  http,
+  parseAbi,
+  zeroAddress,
+} from 'viem'
+import { OperationType } from '@safe-global/types-kit'
+import { Eip1193Provider } from '@safe-global/protocol-kit'
+
+import { formatPrefixedAddress } from '../addresses'
+
+import { chains, defaultRpc } from '../chains'
+
+import {
+  ChainId,
+  MetaTransactionRequest,
+  PrefixedAddress,
+  SafeTransactionRequest,
+} from '../types'
+import { SafeTransactionProperties } from './types'
+
+interface Options {
+  providers?: {
+    [chainId in ChainId]?: string | Eip1193Provider
+  }
+  safeTransactionProperties?: {
+    [safe: PrefixedAddress]: SafeTransactionProperties
+  }
+}
+
+export default async function prepareSafeTransaction({
+  chainId,
+  safe,
+  transaction,
+  options,
+}: {
+  chainId: ChainId
+  safe: Address
+  transaction: MetaTransactionRequest
+  options?: Options
+}): Promise<SafeTransactionRequest> {
+  const provider = getEip1193Provider({ chainId, options })
+  const defaults =
+    options?.safeTransactionProperties?.[formatPrefixedAddress(chainId, safe)]
+
+  const avatarAbi = parseAbi(['function nonce() view returns (uint256)'])
+
+  const nonce = BigInt(
+    (await provider.request({
+      method: 'eth_call',
+      params: [
+        {
+          to: safe,
+          data: encodeFunctionData({
+            abi: avatarAbi,
+            functionName: 'nonce',
+            args: [],
+          }),
+        },
+      ],
+    })) as string
+  )
+
+  return {
+    to: transaction.to,
+    value: transaction.value,
+    data: transaction.data,
+    operation: transaction.operation ?? OperationType.Call,
+    safeTxGas: BigInt(defaults?.safeTxGas || 0),
+    baseGas: BigInt(defaults?.baseGas || 0),
+    gasPrice: BigInt(defaults?.gasPrice || 0),
+    gasToken: getAddress(defaults?.gasToken || zeroAddress) as `0x${string}`,
+    refundReceiver: getAddress(
+      defaults?.refundReceiver || zeroAddress
+    ) as `0x${string}`,
+    nonce: Number(defaults?.nonce || nonce),
+  }
+}
+
+export function getEip1193Provider({
+  chainId,
+  options,
+}: {
+  chainId: ChainId
+  options?: Options
+}): Eip1193Provider {
+  const chain = chainId && chains.find((chain) => chain.chainId === chainId)
+  if (!chain) {
+    throw new Error(`Unsupported chain ID: ${chainId}`)
+  }
+
+  const passedIn = Boolean(
+    options && options.providers && options.providers[chainId]
+  )
+
+  let urlOrProvider
+  if (passedIn) {
+    urlOrProvider = options!.providers![chainId]!
+  } else {
+    urlOrProvider = defaultRpc[chainId]!
+  }
+
+  if (typeof urlOrProvider == 'string') {
+    return createPublicClient({
+      transport: http(urlOrProvider),
+    }) as Eip1193Provider
+  } else {
+    return urlOrProvider
+  }
+}

--- a/src/execute/safeTransaction.ts
+++ b/src/execute/safeTransaction.ts
@@ -31,7 +31,7 @@ interface Options {
   }
 }
 
-export default async function prepareSafeTransaction({
+export async function prepareSafeTransaction({
   chainId,
   safe,
   transaction,

--- a/src/execute/safeTransaction.ts
+++ b/src/execute/safeTransaction.ts
@@ -81,7 +81,7 @@ export async function prepareSafeTransaction({
   }
 }
 
-export function getEip1193Provider({
+function getEip1193Provider({
   chainId,
   options,
 }: {


### PR DESCRIPTION
This PR removes and resolves a dependency on an EIP-1193 provider, which should have been optional. closes #12 

When a provider is not supplied, the a default RPC from airlock is used.