### PR TITLE
Change API of queryAvatars and queryInitiators and export rankRoutes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export {
 
 export { chains } from './chains'
 
-export { queryRoutes, queryAvatars, queryInitiators } from './query'
+export { queryRoutes, queryAvatars, queryInitiators, rankRoutes } from './query'
 
 export {
   planExecution,

--- a/src/query/index.ts
+++ b/src/query/index.ts
@@ -1,4 +1,5 @@
-import type { PrefixedAddress, Route } from '../types'
+import { unprefixAddress } from '../addresses'
+import type { Address, PrefixedAddress, Route } from '../types'
 
 export { calculateRouteId } from './routes'
 
@@ -25,9 +26,11 @@ export const queryRoutes = async (
 
 export const queryAvatars = async (
   initiator: `0x${string}`
-): Promise<Route[]> => {
+): Promise<PrefixedAddress[]> => {
   // in the future we might also include routes to other avatars, such as ERC6551 token-bound accounts
-  return await fetchRoutes(`${SER_API_BASE}/safes/${initiator}`)
+  const routes = await fetchRoutes(`${SER_API_BASE}/safes/${initiator}`)
+
+  return Array.from(new Set(routes.map((route) => route.avatar)))
 }
 
 export const queryInitiators = async (

--- a/src/query/index.ts
+++ b/src/query/index.ts
@@ -35,6 +35,10 @@ export const queryAvatars = async (
 
 export const queryInitiators = async (
   avatar: PrefixedAddress
-): Promise<Route[]> => {
-  return await fetchRoutes(`${SER_API_BASE}/initiators/${avatar}`)
+): Promise<Address[]> => {
+  const routes = await fetchRoutes(`${SER_API_BASE}/initiators/${avatar}`)
+
+  return Array.from(
+    new Set(routes.map((route) => unprefixAddress(route.initiator)))
+  )
 }

--- a/src/query/index.ts
+++ b/src/query/index.ts
@@ -2,6 +2,7 @@ import { unprefixAddress } from '../addresses'
 import type { Address, PrefixedAddress, Route } from '../types'
 
 export { calculateRouteId } from './routes'
+export { rankRoutes } from './rank'
 
 const SER_API_BASE = 'https://ser.gnosisguild.org'
 


### PR DESCRIPTION
- adds export for the `rankRoutes` method

BREAKING CHANGES

- `queryAvatars` does **not** return a list of routes anymore, but a list of addresses
- `queryInitiators` does **not** return a list of routes anymore, but a list of addresses

Fixes #39 

